### PR TITLE
Only allow local redirect paths after login

### DIFF
--- a/src/modules/users/views/viewmodel/LoginForm.tsx
+++ b/src/modules/users/views/viewmodel/LoginForm.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 
 import { useStore } from "@/app/Store";
 import Spinner from "@/core/views/ui/app/Spinner";
+import { isLocalUrl } from "@/utils/isLocalUrl";
 
 interface LoginFormProps {}
 
@@ -12,8 +13,8 @@ const LoginForm: React.FC<LoginFormProps> = () => {
     const { Users } = useStore();
     const { push, query } = useRouter();
     let redirectPath: string = "/";
-    if (query.redirectTo) {
-        redirectPath = decodeURIComponent(query.redirectTo as string);
+    if (typeof query.redirectTo === "string" && isLocalUrl(query.redirectTo)) {
+        redirectPath = decodeURIComponent(query.redirectTo);
     }
 
     const { currentUser, tryToRestoreUser, login } = Users;

--- a/src/utils/isLocalUrl.test.ts
+++ b/src/utils/isLocalUrl.test.ts
@@ -1,0 +1,25 @@
+import { isLocalUrl } from "./isLocalUrl";
+
+describe("isLocalUrl", () => {
+    test.each`
+        url                                     | expected
+        ${"http://some-domain.com/some-path"}   | ${false}
+        ${"https://some-domain.com/some-path"}  | ${false}
+        ${"http://some-domain.com/some-path/"}  | ${false}
+        ${"https://some-domain.com/some-path/"} | ${false}
+        ${"http://some-domain.com"}             | ${false}
+        ${"http://some-domain.com/"}            | ${false}
+        ${"https://some-domain.com"}            | ${false}
+        ${"https://some-domain.com/"}           | ${false}
+        ${"/local-path"}                        | ${true}
+        ${"/local-path/"}                       | ${true}
+        ${"/local-path/some-other-path"}        | ${true}
+        ${"/local-path/some-other-path/"}       | ${true}
+        ${"local-path/some-other-path/"}        | ${false}
+        ${"local-path/some-other-path"}         | ${false}
+        ${"local-path/"}                        | ${false}
+    `("checks if $url is an app-specific URL", ({ url, expected }) => {
+        const result = isLocalUrl(url);
+        expect(result).toEqual(expected);
+    });
+});

--- a/src/utils/isLocalUrl.ts
+++ b/src/utils/isLocalUrl.ts
@@ -1,0 +1,5 @@
+const localUrlRegexp = /^(?!http)\/.*$/;
+
+export function isLocalUrl(url: string): boolean {
+    return localUrlRegexp.test(url);
+}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/14959

With this PR, we make sure that the redirect path used after login is a local one (one that's a part of the application).