### PR TITLE
Update architect-orb to 2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    architect: giantswarm/architect@0.17.0
+    architect: giantswarm/architect@2.1.0
 
 defaults: &defaults
     working_directory: ~/confetti-frontend


### PR DESCRIPTION
Update architect-orb to 2.1.0 which will use giantswarm.github.io as catalog base url. The old behaviour was to use giantswarm.github.com which will be deprecated in april by GitHub. Towards giantswarm/giantswarm#15898